### PR TITLE
Print event specific server urls when prod url is not set

### DIFF
--- a/templates/clojure/src/clojure_bot/api.clj
+++ b/templates/clojure/src/clojure_bot/api.clj
@@ -3,12 +3,19 @@
             [cheshire.core :as json]))
 
 (def local-url "http://localhost:8080")
-(def prod-url "https://bots-of-black-friday.azurewebsites.net")
+(def prod-url "")
 
 (defn url []
-  (if (= (System/getenv "ENV") "development")
-    local-url
-    prod-url))
+  (cond
+    (= (System/getenv "ENV") "development") local-url
+    (= prod-url "") (do
+                      (println "Please set prod-url to point at the server of your Code Camp location instance:")
+                      (println "Oulu: https://bots-of-black-friday-oulu.azurewebsites.net")
+                      (println "Tampere: https://bots-of-black-friday-tampere.azurewebsites.net")
+                      (println "Turku: https://bots-of-black-friday-turku.azurewebsites.net")
+                      (println "Helsinki: https://bots-of-black-friday-helsinki.azurewebsites.net")
+                      (System/exit 1))
+    :else prod-url))
 
 (defn register [player-name]
   (:body (client/post (str (url) "/register")

--- a/templates/ts/src/api.ts
+++ b/templates/ts/src/api.ts
@@ -4,11 +4,22 @@ import { RegisterResponse } from "./types/RegisterResponse";
 import { Move } from "./types/Move";
 
 const LOCAL_URL = "http://localhost:8080";
-const PROD_URL = "https://bots-of-black-friday.azurewebsites.net";
+let PROD_URL = "";
 
 const getUrl = (): string => {
   if (process.env.NODE_ENV === "development") {
     return LOCAL_URL;
+  }
+
+  if (PROD_URL === "") {
+    console.log(
+      "Please set PROD_URL to point at the server of your Code Camp location instance:"
+    );
+    console.log("Oulu: https://bots-of-black-friday-oulu.azurewebsites.net");
+    console.log("Tampere: https://bots-of-black-friday-tampere.azurewebsites.net");
+    console.log("Turku: https://bots-of-black-friday-turku.azurewebsites.net");
+    console.log("Helsinki https://bots-of-black-friday-helsinki.azurewebsites.net");
+    process.exit(1);
   }
   return PROD_URL;
 };


### PR DESCRIPTION
Asetettu prod-url tyhjäksi templateissa ja printataan sen ollessa tyhjä eri eventtien serverien urlit